### PR TITLE
Lock protowhat to update shared image

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -69,3 +69,6 @@ echo 'References to PS1 in /.course_home/.bashrc'
 grep PS1 ${HOME_COPY}/.bashrc
 echo 'Configuration of thunk repository'
 git -C /home/thunk/repo config -l
+
+echo 'locking protowhat'
+pip install git+https://github.com/datacamp/protowhat.git@v1.14.1 --target /var/lib/python/site-packages

--- a/requirements.sh
+++ b/requirements.sh
@@ -71,4 +71,4 @@ echo 'Configuration of thunk repository'
 git -C /home/thunk/repo config -l
 
 echo 'locking protowhat'
-pip install git+https://github.com/datacamp/protowhat.git@v1.14.1 --target /var/lib/python/site-packages
+pip install git+https://github.com/datacamp/protowhat.git@v1.8.0 --target /usr/local/lib/python3.5/dist-packages


### PR DESCRIPTION
This PR install protowhat through the requirements file.
Once this PR is merged into master, the shell shared image can be updated to its newest version in which the has_dir incorrect_msg argument is renamed to msg. (Which is a problem in ex5.1, 5.2 and 5.3)
In a single PR I can then rename this argument and remove the protowhat installation.
This way the course works at all times.
Branches passes: https://www.datacamp.com/teach/editor/1545/builds?branch=lock_protowhat

(This is the last of 2 courses that need to be locked.)